### PR TITLE
Fix some typos

### DIFF
--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -2,7 +2,7 @@
 
 1. First download Defects4J: https://github.com/rjust/defects4j
 2. Follows the Defects4J [Get started](https://github.com/rjust/defects4j#getting-started)
-3. Export Defects4J-repair into your PATH: ```PATH=$PATH:~/<defects4j_pach>/framework/bin```
+3. Export Defects4J into your PATH: ```PATH=$PATH:~/<defects4j_path>/framework/bin```
 4. Checkout all bugs
 ```bash
 for bug in $(seq 1 26); do defects4j checkout -p Chart -v ${bug}b -w ~/projects/chart/chart_${bug}; done
@@ -11,7 +11,7 @@ for bug in $(seq 1 106); do defects4j checkout -p Math -v ${bug}b -w ~/projects/
 for bug in $(seq 1 27); do defects4j checkout -p Time -v ${bug}b -w ~/projects/time/time_${bug}; done
 ```
 5. Edit the Defects4J-repair config: ```src/python/core/Config.py```
-6. Export Defects4J-repair into your PATH: ```PATH=$PATH:~/<defects4j-repair_pach>/src/python/bin```
+6. Export Defects4J-repair into your PATH: ```PATH=$PATH:~/<defects4j-repair_path>/src/python/bin```
 7. Run Defects4J-repair
 ```bash
 defects4j-g5k.py --project all --tools all  


### PR DESCRIPTION
I have got some doubts when I am reading [https://github.com/Spirals-Team/defects4j-repair/blob/master/docs/GetStarted.md](https://github.com/Spirals-Team/defects4j-repair/blob/master/docs/GetStarted.md). The details are as follow:

1) 
> Export **Defects4J-repair** into your PATH: PATH=$PATH:~/<defects4j_**pach**>/framework/bin

> Export Defects4J-repair into your PATH: PATH=$PATH:~/<defects4j-repair_**pach**>/src/python/bin

2)
> Export Defects4J-repair into your PATH: PATH=$PATH:~/<defects4j-repair_pach>/src/python/bin

For the first doubt, I thought the **pach** in sentences are typos, which should be changed to **patch**. And the   **Defects4J-repair**  in the first sentence (as quoted before) should be Defects4J, as I think the `/framework/bin` is the folder in Defects4J benchmark, rather than this project.

Therefore I create this pull request. Thank you for your time and consideration!

For the second doubt, I do not find  any `bin` folder in the path `~/<defects4j-repair_pach>/src/python/` or [https://github.com/Spirals-Team/defects4j-repair/tree/master/src/python](https://github.com/Spirals-Team/defects4j-repair/tree/master/src/python). Any help or guidance would be much appreciated.

Thanks again.

Best,
Dale